### PR TITLE
add abillity to inject environment variables for use by unified ci

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,6 +12,10 @@ on:
       NPM_EMAIL:
         description: 'repository NPM_EMAIL secret passed on'
         required: true   
+      ENVIRONMENT_VARIABLES:
+        description: "Environment variables to be injected for the duration of running the reusable workflow. Passed as one large string"
+        required: false
+
     inputs:
       run_sonarcloud_api_client:
         description: 'Defines if sonarcloud should be run for the api-client package.'
@@ -29,6 +33,13 @@ jobs:
     name: Run CI
     runs-on: ubuntu-latest
     steps:
+      - name: Set environment variables
+        env:
+          envCopy: ${{ secrets.ENVIRONMENT_VARIABLES }}
+        if: "${{ env.envCopy != '' }}"
+        shell: bash
+        run: echo "${{ env.envCopy }}" >> $GITHUB_ENV
+
       - name: Checkout code 🛎️
         uses: actions/checkout@v3
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,13 +33,16 @@ jobs:
     name: Run CI
     runs-on: ubuntu-latest
     steps:
-      - name: Set environment variables
+      - name: Expose github environment as shell variables
         env:
-          envCopy: ${{ secrets.ENVIRONMENT_VARIABLES }}
-        if: "${{ env.envCopy != '' }}"
-        shell: bash
-        run: echo "${{ env.envCopy }}" >> $GITHUB_ENV
-
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          VARS_CONTEXT: ${{ toJson(vars) }}
+        run: |
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          to_envs() { jq -r "to_entries[] | \"\(.key)<<$EOF\n\(.value)\n$EOF\n\""; }
+          echo "$SECRETS_CONTEXT" | to_envs >> $GITHUB_ENV
       - name: Checkout code 🛎️
         uses: actions/checkout@v3
 


### PR DESCRIPTION
I came across this when implementing https://github.com/vuestorefront/sap-commerce-cloud/pull/541

1. SAP repo's `sdk` package runs integraiton tests that require an .env file to be present
1.1 Sure I could just put the .env file into the repo like in bigcommerce, but that's not very future-proof
2. If unified CI workflow didn't exist, I'd just create the .env file in GitHub actions using Linux `cat` and use GitHub secrets interpolation to populate the .env file like a normal person
3. However, I **need** to use the unified CI workflow (that's what that PR is about) I can't just create an .env file like a normal person.
3.1. Reusable workflows, such as as unified CI **must be GitHub actions JOBS, not STEPS**. Unified CI is a separate job that I have no control over. 
3.2 If I added another job above unified CI and created an .env file there, Unified CI wouldn't see the file, because each GitHub action job is isolated from eachother
5. My solution to this is modifying the unified CI action (hopefully this will be merged  

What I'm doing, is taking every secret that github adds, and save it as an env variable. It's a "clever trick" tbh, but it works