### PR TITLE
fix: update publish gh release script

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -79,6 +79,7 @@ jobs:
           commit: "ci: release"
           title: "ci: release"
           createGithubReleases: true
+          publish: echo "Publishing with a github release."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -87,7 +88,7 @@ jobs:
         run: |
          yarn build && \
          npm config --location project set @vsf-enterprise:registry=https://europe-west1-npm.pkg.dev/${{ env.GCP_PROJECT_NAME }}/npm/ && \
-         yarn changeset publish
+         yarn changeset publish && git push --follow-tags
 
       # Remove this step once Verdaccio is removed by the Cloud Team for good.
       # It's possible to use `continue-on-error: true` here for max futureproofing,


### PR DESCRIPTION
It turned out that the `createGithubReleases` flag is not enough to trigger publishing of GH release. There must be a publish script configured -> https://github.com/changesets/action/blob/2bb9bcbd6bf4996a55ce459a630a0aa699457f59/src/index.ts#L53-L101

However, our workflow is more complex and require more than one npm configuration under different circumstances. Therefore, I decided to "artificialy" invoke github release by adding a harmless echo command. It should be enough to create a github release and publish packages in later steps.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
